### PR TITLE
Check grant type in ValidationTokenRequest

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -317,6 +317,10 @@ func (s *Server) ValidationTokenRequest(r *http.Request) (oauth2.GrantType, *oau
 		return "", nil, errors.ErrUnsupportedGrantType
 	}
 
+	if !s.CheckGrantType(gt) {
+		return "", nil, errors.ErrUnsupportedGrantType
+	}
+
 	clientID, clientSecret, err := s.ClientInfoHandler(r)
 	if err != nil {
 		return "", nil, err


### PR DESCRIPTION
For some reason there's a CheckGrantType on server which is never actually called to verify whether the grant type is one of the supported ones during the request validation, only in GetAccessToken.

This adds the check early in the chain to ensure we return a helpful error when an unsupported grant type is used.

This is aimed as a fix for: https://github.com/superseriousbusiness/gotosocial/issues/1546